### PR TITLE
Fix SetName, SetDisplayName bug

### DIFF
--- a/Source/PeterKottas.DotNetCore.WindowsService/HostConfigurator.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/HostConfigurator.cs
@@ -17,7 +17,7 @@ namespace PeterKottas.DotNetCore.WindowsService
 
         public void SetName(string serviceName, bool force = false)
         {
-            if (string.IsNullOrEmpty(innerConfig.Name) || force)
+            if (!string.IsNullOrEmpty(innerConfig.Name) || force)
             {
                 innerConfig.Name = serviceName;
             }
@@ -25,7 +25,7 @@ namespace PeterKottas.DotNetCore.WindowsService
 
         public void SetDisplayName(string displayName, bool force = false)
         {
-            if (string.IsNullOrEmpty(innerConfig.DisplayName) || force)
+            if (!string.IsNullOrEmpty(innerConfig.DisplayName) || force)
             {
                 innerConfig.DisplayName = displayName;
             }
@@ -33,7 +33,7 @@ namespace PeterKottas.DotNetCore.WindowsService
 
         public void SetDescription(string description, bool force = false)
         {
-            if (string.IsNullOrEmpty(innerConfig.Description) || force)
+            if (!string.IsNullOrEmpty(innerConfig.Description) || force)
             {
                 innerConfig.Description = description;
             }


### PR DESCRIPTION
Fix bug which forces you to pass force=true to SetName, SetDisplayName and SetDescription.  After fix, you only need to pass foce=true if the stirng value you are passing is null or empty.