### PR TITLE
Remove warnings about unused variable

### DIFF
--- a/Source/PeterKottas.DotNetCore.WindowsService/Base/Timer.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/Base/Timer.cs
@@ -43,7 +43,7 @@ namespace PeterKottas.DotNetCore.WindowsService.Base
                         this.OnTimer();
                     }
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                 }
 
@@ -54,7 +54,7 @@ namespace PeterKottas.DotNetCore.WindowsService.Base
                         return;
                     }
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                 }
 


### PR DESCRIPTION
I noticed these two warnings when looking at the code.
