### PR TITLE
Target netstandard1.6 for use in netcoreapp1.0 and netcoreapp1.1

### DIFF
--- a/Source/PeterKottas.DotNetCore.WindowsService/PeterKottas.DotNetCore.WindowsService.csproj
+++ b/Source/PeterKottas.DotNetCore.WindowsService/PeterKottas.DotNetCore.WindowsService.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>1.0.16</VersionPrefix>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netstandard1.6</TargetFramework>
     <AssemblyName>PeterKottas.DotNetCore.WindowsService</AssemblyName>
     <PackageId>PeterKottas.DotNetCore.WindowsService</PackageId>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
@@ -17,7 +17,9 @@
     <PackageReference Include="DasMulli.Win32.ServiceUtils" Version="1.0.1" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="PeterKottas.DotNetCore.CmdArgParser" Version="1.0.5" />
+    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I was having a look at if it was possible to target netstandard1.6. It all compiles correctly and I will look at using it in my app. Just thought I would check if there was any particular reason for targeting netcoreapp over netstandard. 

https://github.com/PeterKottas/DotNetCore.WindowsService/issues/15