### PR TITLE
Ensure current directory is ApplicationBasePath

### DIFF
--- a/Source/PeterKottas.DotNetCore.WindowsService/ServiceRunner.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/ServiceRunner.cs
@@ -269,6 +269,7 @@ namespace PeterKottas.DotNetCore.WindowsService
         {
             if (!(sc.Status == ServiceControllerStatus.StartPending | sc.Status == ServiceControllerStatus.Running))
             {
+                Directory.SetCurrentDirectory(PlatformServices.Default.Application.ApplicationBasePath);
                 sc.Start();
                 sc.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromMilliseconds(1000));
                 Console.WriteLine($@"Successfully started service ""{config.Name}"" (""{config.Description}"")");


### PR DESCRIPTION
Ensuring the current directory for the service is where the assembly lives as TopShelf does:

https://github.com/Topshelf/Topshelf/blob/develop/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs#L58

T