### PR TITLE
Service root directory

### DIFF
--- a/Source/PeterKottas.DotNetCore.WindowsService/ServiceRunner.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/ServiceRunner.cs
@@ -269,6 +269,7 @@ namespace PeterKottas.DotNetCore.WindowsService
         {
             if (!(sc.Status == ServiceControllerStatus.StartPending | sc.Status == ServiceControllerStatus.Running))
             {
+                Directory.SetCurrentDirectory(PlatformServices.Default.Application.ApplicationBasePath);
                 sc.Start();
                 sc.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromMilliseconds(1000));
                 Console.WriteLine($@"Successfully started service ""{config.Name}"" (""{config.Description}"")");

--- a/Source/PeterKottas.DotNetCore.WindowsService/ServiceRunner.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/ServiceRunner.cs
@@ -17,6 +17,8 @@ namespace PeterKottas.DotNetCore.WindowsService
     {
         public static int Run(Action<HostConfigurator<SERVICE>> runAction)
         {
+            Directory.SetCurrentDirectory(PlatformServices.Default.Application.ApplicationBasePath);
+        
             var innerConfig = new HostConfiguration<SERVICE>();
             innerConfig.Action = ActionEnum.RunInteractive;
             innerConfig.Name = typeof(SERVICE).FullName;
@@ -269,7 +271,6 @@ namespace PeterKottas.DotNetCore.WindowsService
         {
             if (!(sc.Status == ServiceControllerStatus.StartPending | sc.Status == ServiceControllerStatus.Running))
             {
-                Directory.SetCurrentDirectory(PlatformServices.Default.Application.ApplicationBasePath);
                 sc.Start();
                 sc.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromMilliseconds(1000));
                 Console.WriteLine($@"Successfully started service ""{config.Name}"" (""{config.Description}"")");


### PR DESCRIPTION
Set current directory to the assembly base path on the Run method so the service runs in that folder.

Something similar is done in topshelf

https://github.com/Topshelf/Topshelf/blob/develop/src/Topshelf/Runtime/Windows/WindowsServiceHost.cs#L58