### PR TITLE
New action value rule

### DIFF
--- a/Source/PeterKottas.DotNetCore.WindowsService/Enums/ActionEnum.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/Enums/ActionEnum.cs
@@ -9,6 +9,7 @@ namespace PeterKottas.DotNetCore.WindowsService.Enums
     {
         Install,
         Uninstall,
+        DelayedInstall,
         Run,
         RunInteractive,
         Stop,

--- a/Source/PeterKottas.DotNetCore.WindowsService/HostConfiguration.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/HostConfiguration.cs
@@ -39,7 +39,7 @@ namespace PeterKottas.DotNetCore.WindowsService
         public Action<SERVICE> OnServiceStop { get; set; }
 
         public Action<Exception> OnServiceError { get; set; }
-
+        
         public List<string> ExtraArguments { get; set; }
     }
 }

--- a/Source/PeterKottas.DotNetCore.WindowsService/HostConfigurator.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/HostConfigurator.cs
@@ -68,6 +68,22 @@ namespace PeterKottas.DotNetCore.WindowsService
             }
         }
 
+        public void AddExtraArguments(string arg)
+        {
+            if (!string.IsNullOrEmpty(arg))
+            {
+                innerConfig.ExtraArguments.Add(arg);
+            }
+        }
+
+        public void AddExtraArguments(string[] args)
+        {
+            if (args.Length >= 1)
+            {
+                innerConfig.ExtraArguments.AddRange(args);
+            }
+        }
+
         public void Service(Action<ServiceConfigurator<SERVICE>> serviceConfigAction)
         {
             try

--- a/Source/PeterKottas.DotNetCore.WindowsService/PeterKottas.DotNetCore.WindowsService.csproj
+++ b/Source/PeterKottas.DotNetCore.WindowsService/PeterKottas.DotNetCore.WindowsService.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <Version>2.0.0</Version>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DasMulli.Win32.ServiceUtils" Version="1.0.1" />


### PR DESCRIPTION
Adding a new action parameter value that only installs the service and doesn't run it immediately - similar to pull request #55 but a different way of doing it.

This allows for further configuration before the service is run after the code has been moved into a folder for external use. The service can be started later via the Microsoft Management Console.

