### PR TITLE
Support net461 for better compatibility.

### DIFF
--- a/Source/PeterKottas.DotNetCore.WindowsService/PeterKottas.DotNetCore.WindowsService.csproj
+++ b/Source/PeterKottas.DotNetCore.WindowsService/PeterKottas.DotNetCore.WindowsService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net471</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <Version>2.0.6</Version>
     <AssemblyVersion>2.0.6.0</AssemblyVersion>
     <FileVersion>2.0.6.0</FileVersion>


### PR DESCRIPTION
It would make sense to support net461 rather than net471 as it is more widely available and there isn't any net471 functionality that the code relies upon.