### PR TITLE
Fixed bug which skips the first extra argument on service install

### DIFF
--- a/Source/PeterKottas.DotNetCore.WindowsService/ServiceRunner.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/ServiceRunner.cs
@@ -213,7 +213,7 @@ namespace PeterKottas.DotNetCore.WindowsService
                     PlatformServices.Default.Application.ApplicationName + ".dll");
                 host = string.Format("{0} \"{1}\"", host, appPath);
             }
-            if (!host.EndsWith("dotnet.exe", StringComparison.OrdinalIgnoreCase))
+            else
             {
                 //For self-contained apps, skip the dll path
                 extraArguments = extraArguments.Skip(1).ToList();


### PR DESCRIPTION
Fixes #90 

NOTE: Currently tested against netcoreapp2.0