### PR TITLE
Allow onException timer handler to catch exceptions thrown in async m…

### DIFF
--- a/Source/PeterKottas.DotNetCore.WindowsService/Base/Timers.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/Base/Timers.cs
@@ -27,6 +27,24 @@ namespace PeterKottas.DotNetCore.WindowsService.Base
             }
         }
 
+        public void Start(string timerName, int interval, Func<Task> onTimer, Action<Exception> onException = null)
+        {
+            var tmpTimer = timers.Where(x => x.Name == timerName).FirstOrDefault();
+            if (tmpTimer == null)
+            {
+                tmpTimer = new Timer(timerName, interval, onTimer, onException);
+                timers.Add(tmpTimer);
+
+                tmpTimer.Start();
+            }
+            else
+            {
+                tmpTimer.Stop();
+                Update(timerName, interval, onTimer, onException);
+                tmpTimer.Start();
+            }
+        }
+
         public void Update(string timerName, int interval = 0, Action onTimer = null, Action<Exception> onException = null)
         {
             var tmpTimer = timers.Where(x => x.Name == timerName).FirstOrDefault();
@@ -35,6 +53,26 @@ namespace PeterKottas.DotNetCore.WindowsService.Base
                 if (onTimer != null)
                 {
                     tmpTimer.OnTimer = onTimer;
+                }
+                if (onException != null)
+                {
+                    tmpTimer.OnException = onException;
+                }
+                if (interval > 0 && interval != tmpTimer.Interval)
+                {
+                    tmpTimer.Interval = interval;
+                }
+            }
+        }
+
+        public void Update(string timerName, int interval = 0, Func<Task> onTimerAsync = null, Action<Exception> onException = null)
+        {
+            var tmpTimer = timers.Where(x => x.Name == timerName).FirstOrDefault();
+            if (tmpTimer != null)
+            {
+                if (onTimerAsync != null)
+                {
+                    tmpTimer.OnTimerAsync = onTimerAsync;
                 }
                 if (onException != null)
                 {


### PR DESCRIPTION
Allow onException timer handler to catch exceptions thrown in async methods

Developing my service I came across problem which took me a while to debug. The problem is that when someone passes async lambda method to `Timer onStart` handler - `onException` handler will not be triggered. I believe it's because of the type of `onStart` handler wchich is `Action`. One solution would be to just wrap body of lambda function in additional try catch block:
```
Timers.Start("Poller", 10000, async () =>
{
    try
    {
        await ThrowAsyncException();
    }
    catch (Exception ex)
    {
        _logger.LogError(ex.Message);
    }
}, (err) => { _logger.LogError($"Handler: {err.Message}"); });  
```
But it does not feel right with a method which exposes explicit handler for this.