### PR TITLE
Quote arguments for the service when they contain spaces

### DIFF
--- a/Source/PeterKottas.DotNetCore.WindowsService/ServiceRunner.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/ServiceRunner.cs
@@ -222,16 +222,24 @@ namespace PeterKottas.DotNetCore.WindowsService
             {
                 var appPath = Path.Combine(PlatformServices.Default.Application.ApplicationBasePath,
                     PlatformServices.Default.Application.ApplicationName + ".dll");
-                host = string.Format("{0} \"{1}\"", host, appPath);
+                host = string.Format("{0} \"{1}\"", SanitiseArgument(host), appPath);
             }
             else
             {
                 //For self-contained apps, skip the dll path
                 extraArguments = extraArguments.Skip(1).ToList();
             }
-
-            var fullServiceCommand = string.Format("{0} {1} {2}", host, string.Join(" ", extraArguments), "action:run");
+            var fullServiceCommand = string.Format("{0} {1} {2}", host, string.Join(" ", extraArguments.Select(arg => SanitiseArgument(arg))), "action:run");
             return fullServiceCommand;
+        }
+
+        private static string SanitiseArgument(string arg)
+        {
+            if (string.IsNullOrEmpty(arg))
+            {
+                return arg;
+            }
+            return arg.Contains(" ") ? "\"" + arg + "\"" : arg;
         }
 
         private static void Install(HostConfiguration<SERVICE> config, ServiceController sc, int counter = 0)


### PR DESCRIPTION
Path for dotnet.exe contained a space. This stopped the service from starting for me. I also noticed arguments were missing quotations if they contained spaces and were originally quoted so fixed that.