### PR TITLE
Removed IMicroService references from template classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Community, feel encouraged to add more templates if you find something missing/u
 		}
 	}
 	```
-3. Api for services (and yeah, it's simmilar to Topshelf, thanks for inspiration, I just couldn't wait for you guys to implement this):
+3. Api for services (and yeah, it's similar to Topshelf, thanks for inspiration, I just couldn't wait for you guys to implement this):
 	```cs
 	ServiceRunner<ExampleService>.Run(config =>
 	{

--- a/Source/PeterKottas.DotNetCore.WindowsService/Configurators/Service/ServiceConfigurator.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/Configurators/Service/ServiceConfigurator.cs
@@ -4,25 +4,25 @@ using System.Collections.Generic;
 
 namespace PeterKottas.DotNetCore.WindowsService.Configurators.Service
 {
-    public class ServiceConfigurator<SERVICE> where SERVICE : IMicroService
+    public class ServiceConfigurator<TService>
     {
-        private HostConfiguration<SERVICE> config;
-        public ServiceConfigurator(HostConfiguration<SERVICE> config)
+        private HostConfiguration<TService> config;
+        public ServiceConfigurator(HostConfiguration<TService> config)
         {
             this.config = config;
         }
 
-        public void ServiceFactory(Func<List<string>, IMicroServiceController, SERVICE> serviceFactory)
+        public void ServiceFactory(Func<List<string>, IMicroServiceController, TService> serviceFactory)
         {
             config.ServiceFactory = serviceFactory;
         }
 
-        public void OnStart(Action<SERVICE, List<string>> onStart)
+        public void OnStart(Action<TService, List<string>> onStart)
         {
             config.OnServiceStart = onStart;
         }
 
-        public void OnStop(Action<SERVICE> onStop)
+        public void OnStop(Action<TService> onStop)
         {
             config.OnServiceStop = onStop;
         }
@@ -32,27 +32,27 @@ namespace PeterKottas.DotNetCore.WindowsService.Configurators.Service
             config.OnServiceError = onError;
         }
 
-        public void OnPause(Action<SERVICE> onPause)
+        public void OnPause(Action<TService> onPause)
         {
             config.OnServicePause = onPause;
         }
 
-        public void OnInstall(Action<SERVICE> onInstall)
+        public void OnInstall(Action<TService> onInstall)
         {
             config.OnServiceInstall = onInstall;
         }
 
-        public void OnUnInstall(Action<SERVICE> onUnInstall)
+        public void OnUnInstall(Action<TService> onUnInstall)
         {
             config.OnServiceUnInstall = onUnInstall;
         }
 
-        public void OnContinue(Action<SERVICE> onContinue)
+        public void OnContinue(Action<TService> onContinue)
         {
             config.OnServiceContinue = onContinue;
         }
 
-        public void OnShutdown(Action<SERVICE> onShutdown)
+        public void OnShutdown(Action<TService> onShutdown)
         {
             config.OnServiceShutdown = onShutdown;
         }

--- a/Source/PeterKottas.DotNetCore.WindowsService/ConsoleServiceHost.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/ConsoleServiceHost.cs
@@ -10,7 +10,6 @@ namespace PeterKottas.DotNetCore.WindowsService
 	/// https://github.com/Topshelf/Topshelf/blob/develop/src/Topshelf/Hosts/ConsoleRunHost.cs
 	/// </summary>
 	class ConsoleServiceHost<SERVICE>
-		where SERVICE : IMicroService
 	{
 		private InnerService _consoleService = null;
 		private HostConfiguration<SERVICE> _innerConfig = null;

--- a/Source/PeterKottas.DotNetCore.WindowsService/HostConfiguration.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/HostConfiguration.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using PeterKottas.DotNetCore.WindowsService.Enums;
 using PeterKottas.DotNetCore.WindowsService.Interfaces;
 using DasMulli.Win32.ServiceUtils;
 
 namespace PeterKottas.DotNetCore.WindowsService
 {
-    public class HostConfiguration<SERVICE> where SERVICE : IMicroService
+    public class HostConfiguration<TService>
     {
         public HostConfiguration()
         {
@@ -40,23 +38,23 @@ namespace PeterKottas.DotNetCore.WindowsService
 
         public Win32ServiceCredentials DefaultCred { get; set; } = Win32ServiceCredentials.LocalSystem;
 
-        public SERVICE Service { get; set; }
+        public TService Service { get; set; }
 
-        public Func<List<string>, IMicroServiceController, SERVICE> ServiceFactory { get; set; }
+        public Func<List<string>, IMicroServiceController, TService> ServiceFactory { get; set; }
 
-        public Action<SERVICE, List<string>> OnServiceStart { get; set; }
+        public Action<TService, List<string>> OnServiceStart { get; set; }
 
-        public Action<SERVICE> OnServiceStop { get; set; }
+        public Action<TService> OnServiceStop { get; set; }
 
-        public Action<SERVICE> OnServiceInstall { get; set; }
+        public Action<TService> OnServiceInstall { get; set; }
 
-        public Action<SERVICE> OnServiceUnInstall { get; set; }
+        public Action<TService> OnServiceUnInstall { get; set; }
 
-        public Action<SERVICE> OnServicePause { get; set; }
+        public Action<TService> OnServicePause { get; set; }
 
-        public Action<SERVICE> OnServiceContinue { get; set; }
+        public Action<TService> OnServiceContinue { get; set; }
 
-        public Action<SERVICE> OnServiceShutdown { get; set; }
+        public Action<TService> OnServiceShutdown { get; set; }
 
         public Action<Exception> OnServiceError { get; set; }
 

--- a/Source/PeterKottas.DotNetCore.WindowsService/HostConfigurator.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/HostConfigurator.cs
@@ -1,13 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using PeterKottas.DotNetCore.WindowsService.Configurators.Service;
-using PeterKottas.DotNetCore.WindowsService.Interfaces;
 
 namespace PeterKottas.DotNetCore.WindowsService
 {
-    public class HostConfigurator<SERVICE> where SERVICE : IMicroService
+    public class HostConfigurator<SERVICE>
     {
         HostConfiguration<SERVICE> innerConfig;
         public HostConfigurator(HostConfiguration<SERVICE> innerConfig)

--- a/Source/PeterKottas.DotNetCore.WindowsService/InnerService.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/InnerService.cs
@@ -1,9 +1,6 @@
 ﻿using DasMulli.Win32.ServiceUtils;
 using PeterKottas.DotNetCore.WindowsService.Interfaces;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace PeterKottas.DotNetCore.WindowsService
 {

--- a/Source/PeterKottas.DotNetCore.WindowsService/MicroServiceController.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/MicroServiceController.cs
@@ -1,8 +1,5 @@
 ﻿using PeterKottas.DotNetCore.WindowsService.Interfaces;
 using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace PeterKottas.DotNetCore.WindowsService
 {

--- a/Source/PeterKottas.DotNetCore.WindowsService/ServiceRunner.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/ServiceRunner.cs
@@ -14,7 +14,7 @@ using PeterKottas.DotNetCore.WindowsService.StateMachines;
 
 namespace PeterKottas.DotNetCore.WindowsService
 {
-    public static class ServiceRunner<SERVICE> where SERVICE : IMicroService
+    public static class ServiceRunner<SERVICE>
     {
         public static int Run(Action<HostConfigurator<SERVICE>> runAction)
         {


### PR DESCRIPTION
It doesn't look like ServiceRunner really needs to rely on runtime polymorphism, at least not in the sample code. The code to call to 'start' and 'stop' the service is passed in as a lambda anyway. It looks like the interface is just used to enforce some method names. You can rely on just a template/generic for that, without any type check, at compile time it will pick up if any methods are missing 

Forcing inheritance makes it a little harder to write a .NET agnostic library to provide service logic that could be hosted in any type of app, without really making anything safer. It also means you have to add dependencies to the lib that you might not need in certain hosting configuration.

Alternatively if the interface is needed for a purpose I'm not seeing, it would be nice to move the interface classes to an interface-only library targeting .NET Standard instead.

