### PR TITLE
Updated solution to .net Core 3.0

### DIFF
--- a/Source/PeterKottas.DotNetCore.WindowsService.Example/ExampleService.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService.Example/ExampleService.cs
@@ -22,7 +22,7 @@ namespace PeterKottas.DotNetCore.WindowsService.Example
             this.controller = controller;
         }
 
-        private string fileName = Path.Combine(PlatformServices.Default.Application.ApplicationBasePath, "log.txt");
+        private string fileName = Path.Combine(System.AppContext.BaseDirectory, "log.txt");
         public void Start()
         {
             Console.WriteLine("I started");

--- a/Source/PeterKottas.DotNetCore.WindowsService.Example/ExampleServiceTimer.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService.Example/ExampleServiceTimer.cs
@@ -20,7 +20,7 @@ namespace PeterKottas.DotNetCore.WindowsService.Example
             this.controller = controller;
         }
 
-        private string fileName = Path.Combine(PlatformServices.Default.Application.ApplicationBasePath, "log.txt");
+        private string fileName = Path.Combine(System.AppContext.BaseDirectory, "log.txt");
         public void Start()
         {
             StartBase();

--- a/Source/PeterKottas.DotNetCore.WindowsService.Example/PeterKottas.DotNetCore.WindowsService.Example.csproj
+++ b/Source/PeterKottas.DotNetCore.WindowsService.Example/PeterKottas.DotNetCore.WindowsService.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/Source/PeterKottas.DotNetCore.WindowsService.Example/Program.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService.Example/Program.cs
@@ -8,7 +8,7 @@ namespace PeterKottas.DotNetCore.WindowsService.Example
     {
         public static void Main(string[] args)
         {
-            var fileName = Path.Combine(PlatformServices.Default.Application.ApplicationBasePath, "log.txt");
+            var fileName = Path.Combine(System.AppContext.BaseDirectory, "log.txt");
             ServiceRunner<ExampleService>.Run(config =>
             {
                 var name = config.GetDefaultName();

--- a/Source/PeterKottas.DotNetCore.WindowsService/ServiceRunner.cs
+++ b/Source/PeterKottas.DotNetCore.WindowsService/ServiceRunner.cs
@@ -18,7 +18,7 @@ namespace PeterKottas.DotNetCore.WindowsService
     {
         public static int Run(Action<HostConfigurator<SERVICE>> runAction)
         {
-            Directory.SetCurrentDirectory(PlatformServices.Default.Application.ApplicationBasePath);
+            Directory.SetCurrentDirectory(System.AppContext.BaseDirectory);
 
             var innerConfig = new HostConfiguration<SERVICE>();
             innerConfig.Action = ActionEnum.RunInteractive;
@@ -220,8 +220,8 @@ namespace PeterKottas.DotNetCore.WindowsService
             var host = Process.GetCurrentProcess().MainModule.FileName;
             if (host.EndsWith("dotnet.exe", StringComparison.OrdinalIgnoreCase))
             {
-                var appPath = Path.Combine(PlatformServices.Default.Application.ApplicationBasePath,
-                    PlatformServices.Default.Application.ApplicationName + ".dll");
+                var appPath = Path.Combine(System.AppContext.BaseDirectory,
+                    System.Reflection.Assembly.GetEntryAssembly().GetName().Name + ".dll");
                 host = string.Format("{0} \"{1}\"", SanitiseArgument(host), appPath);
             }
             else

--- a/Source/Templates/PeterKottas.DotNetCore.WindowsService.MinimalTemplate/ExampleService.cs
+++ b/Source/Templates/PeterKottas.DotNetCore.WindowsService.MinimalTemplate/ExampleService.cs
@@ -21,7 +21,7 @@ namespace PeterKottas.DotNetCore.WindowsService.MinimalTemplate
             this.controller = controller;
         }
 
-        private string fileName = Path.Combine(PlatformServices.Default.Application.ApplicationBasePath, "log.txt");
+        private string fileName = Path.Combine(System.AppContext.BaseDirectory, "log.txt");
         public void Start()
         {
             Console.WriteLine("I started");

--- a/Source/Templates/PeterKottas.DotNetCore.WindowsService.MinimalTemplate/PeterKottas.DotNetCore.WindowsService.MinimalTemplate.csproj
+++ b/Source/Templates/PeterKottas.DotNetCore.WindowsService.MinimalTemplate/PeterKottas.DotNetCore.WindowsService.MinimalTemplate.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PeterKottas.DotNetCore.WindowsService" Version="1.0.20" />
+    <ProjectReference Include="..\..\PeterKottas.DotNetCore.WindowsService\PeterKottas.DotNetCore.WindowsService.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Source/Templates/PeterKottas.DotNetCore.WindowsService.MinimalTemplate/Program.cs
+++ b/Source/Templates/PeterKottas.DotNetCore.WindowsService.MinimalTemplate/Program.cs
@@ -9,7 +9,7 @@ namespace PeterKottas.DotNetCore.WindowsService.MinimalTemplate
     {
         public static void Main(string[] args)
         {
-            var fileName = Path.Combine(PlatformServices.Default.Application.ApplicationBasePath, "log.txt");
+            var fileName = Path.Combine(System.AppContext.BaseDirectory, "log.txt");
             ServiceRunner<ExampleService>.Run(config =>
             {
                 var name = config.GetDefaultName();

--- a/Source/Templates/PeterKottas.DotNetCore.WindowsService.StandardTemplate/PeterKottas.DotNetCore.WindowsService.StandardTemplate.csproj
+++ b/Source/Templates/PeterKottas.DotNetCore.WindowsService.StandardTemplate/PeterKottas.DotNetCore.WindowsService.StandardTemplate.csproj
@@ -2,17 +2,20 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
-    <PackageReference Include="PeterKottas.DotNetCore.WindowsService" Version="2.0.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\PeterKottas.DotNetCore.WindowsService\PeterKottas.DotNetCore.WindowsService.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Templates/PeterKottas.DotNetCore.WindowsService.StandardTemplate/Program.cs
+++ b/Source/Templates/PeterKottas.DotNetCore.WindowsService.StandardTemplate/Program.cs
@@ -14,12 +14,12 @@ namespace PeterKottas.DotNetCore.WindowsService.StandardTemplate
         {
 #if !DEBUG
             var configuration = new ConfigurationBuilder()
-                .SetBasePath(PlatformServices.Default.Application.ApplicationBasePath)
+                .SetBasePath(System.AppContext.BaseDirectory)
                 .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
                 .Build();
 #else
             var configuration = new ConfigurationBuilder()
-                .SetBasePath(PlatformServices.Default.Application.ApplicationBasePath)
+                .SetBasePath(System.AppContext.BaseDirectory)
                 .AddJsonFile("appsettings.Development.json", optional: false, reloadOnChange: true)
                 .Build();
 #endif
@@ -33,8 +33,8 @@ namespace PeterKottas.DotNetCore.WindowsService.StandardTemplate
 
                 })
                 .AddOptions()
-                .AddSingleton(new LoggerFactory()
-                .AddConsole())
+                .AddLogging(o=>o.AddConsole())
+            
                 .BuildServiceProvider();
 
             var _logger = svcProvider.GetRequiredService<ILoggerFactory>().CreateLogger<Program>();


### PR DESCRIPTION
Updated packages to latest versions
Updated deprecated PlatformServices references to be compatible with .net Core 3.0 (which caused an exception on .net Core 3 preview 2)
